### PR TITLE
fixed additional BigDecimal expansion error in Pulse.java

### DIFF
--- a/src/main/java/org/knowm/jspice/simulate/transientanalysis/driver/Pulse.java
+++ b/src/main/java/org/knowm/jspice/simulate/transientanalysis/driver/Pulse.java
@@ -52,7 +52,7 @@ public class Pulse extends Driver {
   @Override
   public double getSignal(BigDecimal time) {
 
-    BigDecimal remainderTime = (time.add(phaseBD)).remainder(T).multiply(point5).divide(dutyCycleBD);
+    BigDecimal remainderTime = (time.add(phaseBD)).remainder(T).multiply(point5).divide(dutyCycleBD, MathContext.DECIMAL128);
 
     // up phase
     if (BigDecimal.ZERO.compareTo(remainderTime) <= 0


### PR DESCRIPTION
Found another case for the Pulse source that needs MathContext.128 on the divide() function